### PR TITLE
Fix AmrAlignment.isEmpty

### DIFF
--- a/java/AmrUtils/src/util/corpus/wrappers/AmrAlignment.java
+++ b/java/AmrUtils/src/util/corpus/wrappers/AmrAlignment.java
@@ -118,7 +118,11 @@ public class AmrAlignment
     
     public boolean isEmpty()
     {
-        return wordIds.isEmpty() || (wordIds.size() == 1 && wordIds.get(0) == -1);
+        boolean flag = true
+            for (int i = 0; i < wordIds.size() && flag; i++) {
+                flag = (wordIds.get(i) == -1);
+            }
+        return (wordIds.isEmpty() || flag);
     }
     
     @Override


### PR DESCRIPTION
Sometimes alignments get merged due to name and op nodes for instance, and currently isEmpty doesn't account for this.